### PR TITLE
Breaking Changes: Update fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DynaDoc is a smarter DocumentClient for AWS's DynamoDB and partial ORM written i
 
 With DynaDoc you can specify a Joi schema and create a new Client to represent a table in DynamoDB. DynaDoc will create that table for you and can validate items based on the Joi Schema. The schema can contain Global and Local secondary Indexes that DynaDoc will be able to use and make calls to the DynamoDB table with ease!
 
-Current Version: 0.6.2
+Current Version: 0.7.0
 
 NOTICE: DynaDoc is in Beta. Parts of this project are still under heavy development. It is certainly a good idea to begin developing with DynaDoc as the majority of existing functionality will not be changed so you can get familiar with DynaDoc's features. I am looking for feedback and ideas so please help me make this library better by creating issues and pull requests! :)   The first production instance will be v1.0.0. Planned production release date is: 1/08/2016
 

--- a/lib/dynadoc-client.js
+++ b/lib/dynadoc-client.js
@@ -69,20 +69,6 @@ var SmartBatchGetHelper = require(path.join(LIB_FOLDER, "smartBatchGet"));
 
 var DyModel = require(path.join(DYMODEL_FOLDER, "dymodel"));
 
-/*
-Default settings for the DynaDoc module.
-Never reference a global variable in the constructor unless you
-want it to be shared across all instances (in our case we do not).
-*/
-var DEFAULT_SETTINGS = {
-    ReturnValues: 'NONE',
-    ReturnConsumedCapacity: 'NONE',
-    ReturnItemCollectionMetrics: 'NONE',
-    Limit: 10
-
-}
-
-
 
 /**
 Constructor function. By creating a new one, you can simply
@@ -116,7 +102,9 @@ function DynaDoc(AWS, tableName, model, readCapacity, writeCapacity) {
     For simplicity.
     */
     this.PRIMARY_INDEX_NAME = Util.PRIMARY_INDEX_PLACEHOLDER;
-
+    /*
+    Default settings for the DynaDoc module.
+    */
     this.settings = {
         ReturnValues: 'NONE',
         ReturnConsumedCapacity: 'NONE',
@@ -157,7 +145,7 @@ Settings passed in at creation.
 @param existingPayload (Object): A payload object to add default settings to.
 **/
 function generatePayload(settings) {
-    if (!settings.TableName) {
+    if (!settings.hasOwnProperty("TableName")) {
         //The table name does not exist, so nothing will work.
         throw Util.createError('TableName is not defined.');
     }
@@ -168,8 +156,8 @@ function generatePayload(settings) {
     payload.TableName = settings.TableName;
 
     //Non required settings.
-    payload.ReturnValues = settings.ReturnValue || DEFAULT_SETTINGS.ReturnValue;
-    payload.ReturnConsumedCapacity = settings.ReturnConsumedCapacity || DEFAULT_SETTINGS.ReturnConsumedCapacity;
+    payload.ReturnValues = settings.ReturnValue || "NONE";
+    payload.ReturnConsumedCapacity = settings.ReturnConsumedCapacity || "NONE";
 
     return payload;
 }
@@ -407,9 +395,11 @@ DynaDoc.prototype.queryOne = function queryOne(indexName, keyConditionExpression
     @param hashValue: The value for the hash in whatever datatype the index hash is in.
     @param rangeValue: The range value for the index to compare or search for. (Required if Index Requires it)
     @param action (String; Optional): An action to take on the Range value. Examples: "<", "=", ">=", etc. (Optional, Default: '=')
-    @param limit (integer; Optional): An integer limit to the number of objects to return. (Optional, Default = 10)
 
-    @param additionalOptions (Object; Optional): Additional Options for query found in the AWS SDK. (Optional, Default: null)
+
+    @param options (Object; Optional): Additional Options for query found in the AWS SDK. (Optional, Default: null)
+        - limit (integer; Optional): An integer limit to the number of objects to return. (Optional, Default = 10)
+        - Other AWS Quer options defined in the AWS DynamoDB documentation.
 
     @returns promise: Result of the query to DynamoDB.
 
@@ -424,7 +414,7 @@ DynaDoc.prototype.queryOne = function queryOne(indexName, keyConditionExpression
     This may require a smarter way to handle these parameters.
 
     **/
-DynaDoc.prototype.smartQuery = function smartQuery(indexName, hashValue, rangeValue, action, limit, additionalOptions) {
+DynaDoc.prototype.smartQuery = function smartQuery(indexName, hashValue, rangeValue, action, options) {
     var d = Q.defer();
     //Lets validate the indexName before we start...
     if (!(Util.getIndexes(this.settings)[indexName])) {
@@ -447,15 +437,13 @@ DynaDoc.prototype.smartQuery = function smartQuery(indexName, hashValue, rangeVa
         throw Util.createError('Not enough arguments for smartQuery!');
     }
 
-    if (!limit) {
-        limit = this.settings.Limit;
-    }
-    if (additionalOptions) {
+    //Always set the limit, though it may get overridden in each call.
+    payload.Limit = this.settings.Limit;
+    if (options) {
         //If there are additional options, we should merge them into the payload.
-        payload = Util.mergeObject(payload, additionalOptions);
+        payload = Util.mergeObject(payload, options);
     }
-    //Always set the limit.
-    payload.Limit = limit;
+
     this.dynamoDoc.query(payload, function(err, res) {
         errorCheck(err, d);
         d.resolve(res);
@@ -472,12 +460,13 @@ DynaDoc.prototype.smartQuery = function smartQuery(indexName, hashValue, rangeVa
     @param hashValue: The value for the hash in whatever datatype the index hash is in.
     @param lowerRangeValue: The lower range value for the index to compare or search for.
     @param upperRangeValue: The upper range value for the BETWEEN query.
-    @param limit (Integer; Optional): Limit the number of documents to return (optional, Default = 10);
     @param options (Object): Additional options for smartBetween.
+        - Limit (Integer): Limit the number of documents to return (optional, Default = 10);
+        - Other AWS Options like ScanIndexForward and ReturnConsumedCapacity, etc.
 
     @TODO Integrate thing into smartQuery (since it is a query operation)
 **/
-DynaDoc.prototype.smartBetween = function smartBetween(indexName, hashValue, lowerRangeValue, upperRangeValue, limit, options) {
+DynaDoc.prototype.smartBetween = function smartBetween(indexName, hashValue, lowerRangeValue, upperRangeValue, options) {
     var d = Q.defer();
     //Lets validate the indexName before we start...
     if (!(Util.getIndexes(this.settings)[indexName])) {
@@ -492,14 +481,13 @@ DynaDoc.prototype.smartBetween = function smartBetween(indexName, hashValue, low
     } else {
         throw Util.createError('smartBetween(): Not enough arguments to do a BETWEEN query.');
     }
-    if (!limit) {
-        limit = this.settings.Limit;
-    }
+    //Set the limit payload to the default unless the users specifies something else in options.
+    payload.Limit = this.settings.Limit;
     //Add standard Options.
     if(options) {
         Util.addOptionsToPayload(payload, options);
     }
-    payload.Limit = limit;
+
     this.dynamoDoc.query(payload, function(err, res) {
         errorCheck(err, d);
         d.resolve(res);

--- a/lib/dynadoc-client.js
+++ b/lib/dynadoc-client.js
@@ -473,10 +473,11 @@ DynaDoc.prototype.smartQuery = function smartQuery(indexName, hashValue, rangeVa
     @param lowerRangeValue: The lower range value for the index to compare or search for.
     @param upperRangeValue: The upper range value for the BETWEEN query.
     @param limit (Integer; Optional): Limit the number of documents to return (optional, Default = 10);
+    @param options (Object): Additional options for smartBetween.
 
     @TODO Integrate thing into smartQuery (since it is a query operation)
 **/
-DynaDoc.prototype.smartBetween = function smartBetween(indexName, hashValue, lowerRangeValue, upperRangeValue, limit) {
+DynaDoc.prototype.smartBetween = function smartBetween(indexName, hashValue, lowerRangeValue, upperRangeValue, limit, options) {
     var d = Q.defer();
     //Lets validate the indexName before we start...
     if (!(Util.getIndexes(this.settings)[indexName])) {
@@ -493,6 +494,10 @@ DynaDoc.prototype.smartBetween = function smartBetween(indexName, hashValue, low
     }
     if (!limit) {
         limit = this.settings.Limit;
+    }
+    //Add standard Options.
+    if(options) {
+        Util.addOptionsToPayload(payload, options);
     }
     payload.Limit = limit;
     this.dynamoDoc.query(payload, function(err, res) {
@@ -779,7 +784,7 @@ a full description of the table to parse. For now we will require that users
 use Describe table after an update to ensure that the table is accurate.
 **/
 DyModel.prototype.updateTable = function updateTable() {
-    if (!this.tablePayload) {
+    if (!this.hasOwnProperty("tablePayload")) {
         //If there is no tablePayload, then we cannot update the table.
         throw Util.createError('Unable to update table as there is nothing new to update.');
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -82,7 +82,7 @@ const ERROR_GLOBAL_PREFIX = "DynaDoc: ";
     Get the Indexes object for
 **/
 util.getIndexes =  function getIndexes(settings) {
-    if (!settings.Indexes) {
+    if (!settings.hasOwnProperty("Indexes")) {
         settings.Indexes = {};
     }
     return settings.Indexes;
@@ -200,14 +200,14 @@ util.addOptionsToPayload = function addOptionsToPayload(payload, options) {
     Only usable in: Put, Update, and Delete.
     Need to check and make sure it is not sent otherwise DynamoDB will return validation Errors.
     */
-    if (options.ReturnValues) {
+    if (options.hasOwnProperty(ReturnValues)) {
         payload.ReturnValues = options.ReturnValues;
     }
     //Check if they want to get Returned consumedCapacity
     /*
     Availalbe in every method but CreateSet. (CreateSet will likely not be implemented).
     */
-    if (options.ReturnConsumedCapacity) {
+    if (options.hasOwnProperty(ReturnConsumedCapacity)) {
         payload.ReturnConsumedCapacity = options.ReturnConsumedCapacity;
     }
 
@@ -216,14 +216,18 @@ util.addOptionsToPayload = function addOptionsToPayload(payload, options) {
     Use only in: batchWrite, Put, Delete, and Update.
     Not availalbe in other methods.
     */
-    if (options.ReturnItemCollectionMetrics) {
+    if (options.hasOwnProperty(ReturnItemCollectionMetrics)) {
         payload.ReturnItemCollectionMetrics = options.ReturnItemCollectionMetrics;
     }
     /*
     Set the default limit of items returned.
     */
-    if (options.Limit) {
+    if (options.hasOwnProperty(Limit)) {
         payload.Limit = options.Limit;
+    }
+
+    if (options.hasOwnProperty(ScanIndexForward)) {
+        payload.ScanIndexForward = ScanIndexForward;
     }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -200,14 +200,14 @@ util.addOptionsToPayload = function addOptionsToPayload(payload, options) {
     Only usable in: Put, Update, and Delete.
     Need to check and make sure it is not sent otherwise DynamoDB will return validation Errors.
     */
-    if (options.hasOwnProperty(ReturnValues)) {
+    if (options.hasOwnProperty("ReturnValues")) {
         payload.ReturnValues = options.ReturnValues;
     }
     //Check if they want to get Returned consumedCapacity
     /*
     Availalbe in every method but CreateSet. (CreateSet will likely not be implemented).
     */
-    if (options.hasOwnProperty(ReturnConsumedCapacity)) {
+    if (options.hasOwnProperty("ReturnConsumedCapacity")) {
         payload.ReturnConsumedCapacity = options.ReturnConsumedCapacity;
     }
 
@@ -216,17 +216,17 @@ util.addOptionsToPayload = function addOptionsToPayload(payload, options) {
     Use only in: batchWrite, Put, Delete, and Update.
     Not availalbe in other methods.
     */
-    if (options.hasOwnProperty(ReturnItemCollectionMetrics)) {
+    if (options.hasOwnProperty("ReturnItemCollectionMetrics")) {
         payload.ReturnItemCollectionMetrics = options.ReturnItemCollectionMetrics;
     }
     /*
     Set the default limit of items returned.
     */
-    if (options.hasOwnProperty(Limit)) {
+    if (options.hasOwnProperty("Limit")) {
         payload.Limit = options.Limit;
     }
 
-    if (options.hasOwnProperty(ScanIndexForward)) {
+    if (options.hasOwnProperty("ScanIndexForward")) {
         payload.ScanIndexForward = ScanIndexForward;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dynadoc",
-    "version": "0.6.2",
+    "version": "0.7.0",
     "description": "An easier and intelligent way to use DynamoDB.",
     "main": "dynadoc.js",
     "scripts": {

--- a/test/dynatest.js
+++ b/test/dynatest.js
@@ -715,8 +715,7 @@ describe('DyModel Test Suite', function() {
         return dynaTable1.smartQuery(testData.t1GlobalIndexName,
           testData.t1Data[0].GlobalSecondaryHash,
           testData.t1Data[0].GlobalSecondaryRange,
-          "=",
-          12).then(function(result) {
+          "=", {Limit: 12}).then(function(result) {
           /*
           For some reason returning the promise in above does not
           catch the assertions that happen when the test fails.
@@ -744,7 +743,7 @@ describe('DyModel Test Suite', function() {
           testData.t1Data[0].GlobalSecondaryHash,
           testData.t1Data[0].GlobalSecondaryRange,
           "=",
-          12, {
+          {
             "ReturnConsumedCapacity": "TOTAL",
             "ScanIndexForward": false
           }).then(function(result) {
@@ -819,10 +818,10 @@ describe('DyModel Test Suite', function() {
         dynaTable1.smartQuery(dynaTable1.PRIMARY_INDEX_NAME,
           testData.t1Data[2].PrimaryHashKey,
           null,
-          "=",
-          12, {
+          "=",{
             "ReturnConsumedCapacity": "TOTAL",
-            "ScanIndexForward": false
+            "ScanIndexForward": false,
+            "Limit": 12
           }).then(function(result) {
           /*
           For some reason returning the promise in above does not
@@ -851,7 +850,7 @@ describe('DyModel Test Suite', function() {
         return dynaTable1.smartBetween(dynaTable1.PRIMARY_INDEX_NAME,
           testData.t1Data[1].PrimaryHashKey,
           testData.t1Data[1].PrimaryRangeKey,
-          testData.t1Data[2].PrimaryRangeKey, 5).then(function(result) {
+          testData.t1Data[2].PrimaryRangeKey, {Limit: 5}).then(function(result) {
           try {
             expect(result).to.have.property("Items");
             expect(result).to.have.property("Count", 2);


### PR DESCRIPTION
Not following Semantic versioning until 1.0.0 is released.

Update V0.7.0 which breaks smartQuery and smartBetween by removing Limit param and placing as within the options param.