### PR TITLE
Added global options to DynaDoc. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
 - 'stable'
+- '4.2.6'
 - '4.1'
-- '4.0'
 env:
   global:
   - secure: t8qd0afSCU1fxVNu3QhnkMWcRlyc+6Ec0OfwQpVLjbpRBjYR0oEWTPImHMSpCpGnyXfGROqwaxHjRtsPsuhIgy02ke0l9qhoxKp4l+Hqx7iIRxu8ZPA0TwqTRuipGH7/3U3tVzriDtvkDQtUNaUgPVI6wFSiLqqXII1G9ypaDaK+h1fw2vEcRp5ziqPkHw6kUbAG9YIiRahd7LqGlvT8qc8Ohn5LJ4zXhx0Vm7MHQrSRkmPHmHJlSYNgVkfGe+3FyxE900VK12XILkt2PkKvh/4E8e0EsQS2h1H6M+6oSX/h3zy7R5lKMNnsMPpqUtCfjmViwd5FdCdAIDEYfgls2IAFwntWysuTUT7CrYO8J+D4mBouRDhgSrylao9KvTdyto1hQzs1PptWjCjgdLOIPQn2wv22rfLwcti1f89Db3dWzDJi7hA4cdAvZ29VpoaSMXNUGLJTxZoB+PgS0VfpYgYD4mPH1SmHXvDqn1ZR9ZIY4afnSXUCury3FcPU0GOvjV/+0OCaVNJFl4e0Fv+Hs3jcLj/bzlm9To0GS2hbYrpt4yUNTXYYCF/ACdnf9cRSSEOQQJ7xy7t5AnZWlt68+jJb0VhK94+cZvfCMR0idvBOO8Qf4wM+nNfmpr2Zars6yO0uqUdvgrhnxJJNnu/pwWqmv+WYR1FMlQAK/IfOREM=

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DynaDoc is a smarter DocumentClient for AWS's DynamoDB and partial ORM written i
 
 With DynaDoc you can specify a Joi schema and create a new Client to represent a table in DynamoDB. DynaDoc will create that table for you and can validate items based on the Joi Schema. The schema can contain Global and Local secondary Indexes that DynaDoc will be able to use and make calls to the DynamoDB table with ease!
 
-Current Version: 0.7.2
+Current Version: 0.7.3
 
 NOTICE: DynaDoc is in Beta. Parts of this project are still under heavy development. It is certainly a good idea to begin developing with DynaDoc as the majority of existing functionality will not be changed so you can get familiar with DynaDoc's features. I am looking for feedback and ideas so please help me make this library better by creating issues and pull requests! :)   The first production instance will be v1.0.0. Milestones are set for production release.
 

--- a/dynadoc.js
+++ b/dynadoc.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
 The contents of this file are subject to the Common Public Attribution License
 Version 1.0 (the “License”); you may not use this file except in compliance
@@ -34,8 +35,8 @@ var Util = require(path.join(LIB_FOLDER, 'util'));
 var DynaClient = require(path.join(LIB_FOLDER, 'dynadoc-client'));
 //Require Joi so our users will not have too.
 var Joi = require('joi');
-
-const OPTION_TABLE_PREFIX = "TablePrefix";
+//Not using const yet to better support older versions. Option Prefix.
+var OPTION_TABLE_PREFIX = "TablePrefix";
 
 //Singleton factory constructor
 function DynaFactory() {

--- a/dynadoc.js
+++ b/dynadoc.js
@@ -35,9 +35,12 @@ var DynaClient = require(path.join(LIB_FOLDER, 'dynadoc-client'));
 //Require Joi so our users will not have too.
 var Joi = require('joi');
 
+const OPTION_TABLE_PREFIX = "TablePrefix";
+
 //Singleton factory constructor
 function DynaFactory() {
     this.AWS = null;
+    this.options = {};
 };
 
 /**
@@ -50,21 +53,71 @@ DynaFactory.prototype.setup = function setup(AWS) {
 }
 
 /**
+A function for setting global options for DynaDoc. Options include:
+TablePrefix <String>: A table prefix string that is applied to every
+     table created by any client made.
+**/
+DynaFactory.prototype.setGlobalOptions = function setGlobalOptions(options) {
+    if (options.hasOwnProperty(OPTION_TABLE_PREFIX)) {
+        this.options[OPTION_TABLE_PREFIX] = options[OPTION_TABLE_PREFIX];
+    }
+}
+/**
+Remove a global option from DynaDoc.
+Return true if the option was found and removed.
+False if the option was not found.
+**/
+DynaFactory.prototype.removeGlobalOption = function removeGlobalOption(optionName) {
+    if (this.options.hasOwnProperty(optionName)) {
+        delete this.options[optionName];
+        return true;
+    }
+    return false;
+}
+
+/**
+Returns the value of a global option given its name.
+**/
+DynaFactory.prototype.getGlobalOption = function getGlobalOption(optionName) {
+    if (this.options.hasOwnProperty(optionName)) {
+        return this.options[optionName]
+    }
+    return null;
+}
+/**
+Checks if DynaDoc has a global options set or not.
+Return true if the option exists and false otherwise.
+**/
+DynaFactory.prototype.hasGlobalOption = function hasGlobalOption(optionName) {
+    if (this.options.hasOwnProperty(optionName)) {
+        return true;
+    }
+    return false;
+}
+
+
+/**
 Creates a new DynaClient for a table.
 
 @param tableName (String): The string name of the table to parse.
 @param model (Object): Joi schema that represents the Table Object. [Optional]
 @param readCapacity (integer): The number of read unites for this table.  [Optional]
 @param writeCapacity (integer): The number of write units for this table. [Optional]
+@param options     (String): Options for creating a client.
 
 @returns DynaClient (Object): The client for communicating with this table.
 **/
-DynaFactory.prototype.createClient = function createClient(tableName, model, readCapacity, writeCapacity) {
+DynaFactory.prototype.createClient = function createClient(tableName, model, readCapacity, writeCapacity, options) {
     if (DynaFactory.AWS === null) {
         //The setup method has not been called.
         throw Util.createError('Setup method has not yet been called! Cannot create Client.');
     }
-    return new DynaClient(DynaFactory.AWS, tableName, model, readCapacity, writeCapacity);
+    //Append options.
+    if (this.hasGlobalOption(OPTION_TABLE_PREFIX)) {
+        tableName = this.getGlobalOption(OPTION_TABLE_PREFIX) + tableName;
+    }
+
+    return new DynaClient(DynaFactory.AWS, tableName, model, readCapacity, writeCapacity, options);
 }
 
 /**

--- a/lib/dynadoc-client.js
+++ b/lib/dynadoc-client.js
@@ -81,10 +81,11 @@ description of the table.
 @param model (Object): Joi schema that represents the Table Object.
 @param readCapacity (integer): The number of read unites for this table.
 @param writeCapacity (integer): The number of write units for this table.
+@param options (String): Global options for this DynaDoc Client.
 
 @returns dynaClient (Object): New Instance of DynaDoc.
 **/
-function DynaDoc(AWS, tableName, model, readCapacity, writeCapacity) {
+function DynaDoc(AWS, tableName, model, readCapacity, writeCapacity, options) {
 
     if (!tableName) {
         //The table name does not exist, so nothing will work.
@@ -121,7 +122,6 @@ function DynaDoc(AWS, tableName, model, readCapacity, writeCapacity) {
         }
         //@TODO We should make sure we were given a valid Joi Schema.
         //The Joi Schema that validates input to this DynaClient.
-        //this.dymodel = new DyModel(tableName, model, this.dynamoDB, readCapacity, writeCapacity);
         Util.mergeObject(this, new DyModel(tableName, model, dynamoDBClient, readCapacity, writeCapacity));
     }
     Util.mergeObject(this, Constants);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dynadoc",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "description": "An easier and intelligent way to use DynamoDB.",
     "main": "dynadoc.js",
     "scripts": {

--- a/test/dynatest.js
+++ b/test/dynatest.js
@@ -86,9 +86,22 @@ console.log('Table 2 Name: ' + table2Name);
 var table1ReadCapacity = 10;
 var table1WriteCapacity = 10;
 
+
+
 var dynaTable1 = DynaDoc.createClient(table1Name, testData.t1Schema, table1ReadCapacity, table1WriteCapacity);
+//Set a global Prefix for the tables.
+DynaDoc.setGlobalOptions({
+    TablePrefix: testData.TABLE_NAME2_PREFIX
+});
 var dynaTable2 = DynaDoc.createClient(table2Name, testData.t2Schema, 10, 8);
 
+//Make a copy of the table2Name so it does not simply reference it.
+var noPrefixTable2Name = new String(table2Name);
+/*
+The prefix is added by DynaDoc object for the client. This adds the
+prefix to be used every in the test document.
+*/
+table2Name = dynaTable2.getTableName();
 
 //The default timeout for every call.
 var DEFAULT_TIMEOUT = 3500;
@@ -185,7 +198,7 @@ describe('DyModel Test Suite', function() {
     });
 
     it('Attempt to create Table 2 again using ignore parameter.', function(done) {
-      var tempClient = DynaDoc.createClient(table2Name, testData.t2Schema, 1, 1);
+      var tempClient = DynaDoc.createClient(noPrefixTable2Name, testData.t2Schema, 1, 1);
       tempClient.ensurePrimaryIndex("CustomerID");
       tempClient.ensureGlobalIndex("gameID", undefined, 1, 1, testData.t2GameIDIndexName);
       tempClient.createTable(true).then(function(res) {
@@ -349,7 +362,7 @@ describe('DyModel Test Suite', function() {
     Deletes both a global and local index.
     */
     it('Delete Global gameID index from table 2', function(done) {
-      this.timeout(70000);
+      this.timeout(80000);
       dynaTable2.deleteIndex(testData.t2GameIDIndexName);
       //Kind of defeating the purpose of promises by waiting, but we need to.
       dynaTable2.updateTable().then(function(res) {

--- a/test/test_data.js
+++ b/test/test_data.js
@@ -33,6 +33,7 @@ var testData = {};
 
 
 testData.TABLE_NAME1 = "DynaDocTest1";
+testData.TABLE_NAME2_PREFIX = "Table2-";
 testData.TABLE_NAME2 = "DynaDocTest2";
 
 const T1PrimaryHashKeyName = "PrimaryHashKey";


### PR DESCRIPTION
Currently, only the ability to add a prefix to every table name. This will be helpful for environment staging and automated testing to keep test environments separate from production within the same region.